### PR TITLE
feat: Support multiple XFF headers

### DIFF
--- a/realip.go
+++ b/realip.go
@@ -71,11 +71,13 @@ func FromRequest(r *http.Request) string {
 	}
 
 	// Check list of IP in X-Forwarded-For and return the first global address
-	for _, address := range xForwardedFor {
-		address = strings.TrimSpace(address)
-		isPrivate, err := isPrivateAddress(address)
-		if !isPrivate && err == nil {
-			return address
+	for _, a := range xForwardedFor {
+		for _, b := range strings.Split(a, ",") {
+			address := strings.TrimSpace(b)
+			isPrivate, err := isPrivateAddress(address)
+			if !isPrivate && err == nil {
+				return address
+			}
 		}
 	}
 

--- a/realip.go
+++ b/realip.go
@@ -53,10 +53,10 @@ func isPrivateAddress(address string) (bool, error) {
 func FromRequest(r *http.Request) string {
 	// Fetch header value
 	xRealIP := r.Header.Get("X-Real-Ip")
-	xForwardedFor := r.Header.Get("X-Forwarded-For")
+	xForwardedFor, _ := r.Header["X-Forwarded-For"]
 
 	// If both empty, return IP from remote address
-	if xRealIP == "" && xForwardedFor == "" {
+	if xRealIP == "" && len(xForwardedFor) == 0 {
 		var remoteIP string
 
 		// If there are colon in remote address, remove the port number
@@ -71,7 +71,7 @@ func FromRequest(r *http.Request) string {
 	}
 
 	// Check list of IP in X-Forwarded-For and return the first global address
-	for _, address := range strings.Split(xForwardedFor, ",") {
+	for _, address := range xForwardedFor {
 		address = strings.TrimSpace(address)
 		isPrivate, err := isPrivateAddress(address)
 		if !isPrivate && err == nil {

--- a/realip_test.go
+++ b/realip_test.go
@@ -1,6 +1,7 @@
 package realip
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -74,6 +75,14 @@ func TestRealIP(t *testing.T) {
 		}, {
 			name:     "Has X-Forwarded-For",
 			request:  newRequest("", "", publicAddr1),
+			expected: publicAddr1,
+		}, {
+			name:     "Has X-Forwarded-For multiple IPs (comma separated)(",
+			request:  newRequest("", "", fmt.Sprintf("%s,%s", localAddr, publicAddr1)),
+			expected: publicAddr1,
+		}, {
+			name:     "Has X-Forwarded-For multiple IPs (comma and then space)",
+			request:  newRequest("", "", fmt.Sprintf("%s, %s", localAddr, publicAddr1)),
 			expected: publicAddr1,
 		}, {
 			name:     "Has multiple X-Forwarded-For",

--- a/realip_test.go
+++ b/realip_test.go
@@ -52,7 +52,7 @@ func TestRealIP(t *testing.T) {
 		h := http.Header{}
 		h.Set("X-Real-IP", xRealIP)
 		for _, address := range xForwardedFor {
-			h.Set("X-Forwarded-For", address)
+			h.Add("X-Forwarded-For", address)
 		}
 
 		return &http.Request{
@@ -78,7 +78,7 @@ func TestRealIP(t *testing.T) {
 		}, {
 			name:     "Has multiple X-Forwarded-For",
 			request:  newRequest("", "", localAddr, publicAddr1, publicAddr2),
-			expected: publicAddr2,
+			expected: publicAddr1,
 		}, {
 			name:     "Has X-Real-IP",
 			request:  newRequest("", publicAddr1),


### PR DESCRIPTION
    fix: to truly support xff headers we need to query Header directly

    When we use Header.Get only the first entry is fetched.

    Per https://golang.org/src/net/http/request.go,
    when there are multiple entries of the same header,
    accessing the map directly allows us to get those
    multiple entries in an array.

    // Header contains the request header fields either received
    // by the server or to be sent by the client.
    //
    // If a server received a request with header lines,
    //
    //  Host: example.com
    //  accept-encoding: gzip, deflate
    //  Accept-Language: en-us
    //  fOO: Bar
    //  foo: two
    //
    // then
    //
    //  Header = map[string][]string{
    //          "Accept-Encoding": {"gzip, deflate"},
    //          "Accept-Language": {"en-us"},
    //          "Foo": {"Bar", "two"},